### PR TITLE
Fix bounds checking for 4K sector drives

### DIFF
--- a/viostor/virtio_stor.c
+++ b/viostor/virtio_stor.c
@@ -1282,7 +1282,7 @@ RhelScsiGetCapacity(
 
     blocksize = adaptExt->info.blk_size;
     lastLBA = adaptExt->info.capacity / (blocksize / SECTOR_SIZE) - 1;
-    adaptExt->lastLBA = lastLBA;
+    adaptExt->lastLBA = adaptExt->info.capacity;
 
     if (Srb->DataTransferLength == sizeof(READ_CAPACITY_DATA)) {
         if (lastLBA > 0xFFFFFFFF) {


### PR DESCRIPTION
Each I/O request LBA is already adjusted for 4K sector size as its processed. No need to adjust the lastLBA in the driver extension; doing so breaks the boundary check.